### PR TITLE
fixedissues

### DIFF
--- a/assets/scripts/fetch.js
+++ b/assets/scripts/fetch.js
@@ -19,6 +19,9 @@ function hideSpinner() {
     loadingEl.classList.remove("active");
 }
 
+let ingredientDropDownOpen = false;
+
+
 const displayMeal = () => {
     document.getElementById('dropdown-menu').addEventListener('change', () => {
         const category = document.getElementById('dropdown-menu').value;
@@ -58,6 +61,7 @@ const displayMeal = () => {
             /* Add image */
             const mealImage = document.getElementById("mealImage");
             mealImage.src = randomRecipe.strMealThumb;
+            mealImage.alt = randomRecipe.strMeal;
 
             /* Add meal source */
             const mealSource = document.getElementById("mealSource");
@@ -81,6 +85,7 @@ const displayMeal = () => {
 
             /* Loops through the ingredients list */
             function getIngredients(randomRecipe) {
+                
                 const mealingredientList = document.getElementById('mealingredientList');
                 mealingredientList.innerHTML = '';
 
@@ -99,7 +104,17 @@ const displayMeal = () => {
                 }  
             }
 
-            getIngredients(randomRecipe);
+           document.getElementById('Ingredients').addEventListener('click',()=>{
+            ingredientDropDownOpen = !ingredientDropDownOpen;
+             if(ingredientDropDownOpen){
+              getIngredients(randomRecipe);
+             }else{
+                document.getElementById('mealingredientList').innerHTML = '<div></div>';
+             }
+             
+           })
+           document.getElementById('Ingredients').style.cursor = 'pointer'
+           document.getElementById('Ingredients').title = 'All Ingredients'
 
             recipeContainer.scrollIntoView({ behavior: 'smooth' });
 

--- a/index.html
+++ b/index.html
@@ -53,13 +53,13 @@
 
         <article>
             <aside>
-                <p>Ingredients</p>
+                <p id="Ingredients">Ingredients</p>
                 <ol id="mealingredientList"></ol>
             </aside>
 
             <article id="mealDescription">
                 <h1 id="mealTitle"></h1>
-                <img id="mealImage" src="" />
+                <img id="mealImage" src="" alt="mealImage" />
             </article>
         </article>
 


### PR DESCRIPTION


What did I change?

I have made Ingredients list collapsable
Added alt text to recipe images

 Why did I make this change?

The ingredients list can be quite long and takes up valuable screen space, especially on mobile devices. A collapsible section would let users focus on the recipe instructions when they don't need to see the ingredients, creating a cleaner, more organized layout.
The recipe images  don't had alt text, making the app less accessible for users who rely on screen readers. Good alt text helps all users understand what's in the image.

How did I test it?

-  Tested in a web browser
-  Tried different meal categories
- Checked on mobile (if you changed styling)

Screenshots 

<img width="1366" height="768" alt="Screenshot (106)" src="https://github.com/user-attachments/assets/f439df7e-70e4-4313-a623-19b9efdccea7" />
<img width="1366" height="768" alt="Screenshot (108)" src="https://github.com/user-attachments/assets/8d3ad886-9195-4a46-9763-afeba6562634" />
<img width="1366" height="768" alt="Screenshot (107)" src="https://github.com/user-attachments/assets/24d59b06-b661-4314-9a62-2c9aeeb97c1c" />
