### PR TITLE
Add alt text to recipe images for accessibility

### DIFF
--- a/assets/scripts/fetch.js
+++ b/assets/scripts/fetch.js
@@ -58,6 +58,7 @@ const displayMeal = () => {
             /* Add image */
             const mealImage = document.getElementById("mealImage");
             mealImage.src = randomRecipe.strMealThumb;
+            mealImage.alt = `An image of ${randomRecipe.strMeal}`;
 
             /* Add meal source */
             const mealSource = document.getElementById("mealSource");


### PR DESCRIPTION
## What did you change?

Added proper alt text to recipe images to improve accessibility for screen reader users.

## Why did you make this change?

The recipe images currently don't have alt text, making the app less accessible for users who rely on screen readers. Good alt text helps all users understand what's in the image.

## How did you test it?

 ✅ Tested in a web browser
 ✅ Tried different meal categories
 ✅ Checked on mobile (if you changed styling)